### PR TITLE
Update to use apple/swift-distributed-tracing 1.0.0-beta.2.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,8 +9,9 @@ jobs:
       fail-fast: false
       matrix:
         images:
-        - swift:5.3
-        - swiftlang/swift:nightly-master
+        - swift:5.7
+        - swift:5.8
+        - swiftlang/swift:nightly-main-focal
     container: ${{ matrix.images }}
     steps:
       - name: Checkout
@@ -18,4 +19,4 @@ jobs:
       - name: Resolve Swift dependencies
         run: swift package resolve
       - name: Build & Test
-        run: swift test --enable-test-discovery --parallel
+        run: swift test --parallel

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .build/
 .swiftpm/
 Documentation/
+Package.resolved

--- a/Package.swift
+++ b/Package.swift
@@ -1,17 +1,18 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.7
 import PackageDescription
 
 let package = Package(
-    name: "opentelemetry-swift-xray",
+    name: "swift-otel-xray",
+    platforms: [.macOS(.v13)],
     products: [
         .library(name: "OpenTelemetryXRay", targets: ["OpenTelemetryXRay"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/slashmo/opentelemetry-swift.git", .upToNextMinor(from: "0.1.1")),
+        .package(url: "https://github.com/slashmo/swift-otel.git", .upToNextMinor(from: "0.7.0")),
     ],
     targets: [
         .target(name: "OpenTelemetryXRay", dependencies: [
-            .product(name: "OpenTelemetry", package: "opentelemetry-swift"),
+            .product(name: "OpenTelemetry", package: "swift-otel"),
         ]),
         .testTarget(name: "OpenTelemetryXRayTests", dependencies: [
             .target(name: "OpenTelemetryXRay"),

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # X-Ray Support for OpenTelemetry Swift
 
-[![Swift 5.3](https://img.shields.io/badge/Swift-5.3-%23f05137)](https://swift.org)
-[![Made for Swift Distributed Tracing](https://img.shields.io/badge/Made%20for-Swift%20Distributed%20Tracing-%23f05137)](https://github.com/apple/swift-distributed-tracing)
 [![CI](https://github.com/slashmo/opentelemetry-swift-xray/actions/workflows/ci.yaml/badge.svg)](https://github.com/slashmo/opentelemetry-swift-xray/actions/workflows/ci.yaml)
+[![Swift 5.7](https://img.shields.io/badge/Swift-5.7-%23f05137)](https://swift.org)
+[![Made for Swift Distributed Tracing](https://img.shields.io/badge/Made%20for-Swift%20Distributed%20Tracing-%23f05137)](https://github.com/apple/swift-distributed-tracing)
 
 This library adds support for [AWS X-Ray](https://aws.amazon.com/xray/) to [OpenTelemetry Swift](https://github.com/slashmo/opentelemetry-swift).
 


### PR DESCRIPTION
Update to use apple/swift-distributed-tracing 1.0.0-beta.2 by updating to the latest version of slashmo/swift-otel.