### PR TITLE
Update slashmo/swift-otel dependency.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
         .library(name: "OpenTelemetryXRay", targets: ["OpenTelemetryXRay"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/slashmo/swift-otel.git", .upToNextMinor(from: "0.7.0")),
+        .package(url: "https://github.com/slashmo/swift-otel.git", .upToNextMinor(from: "0.8.0")),
     ],
     targets: [
         .target(name: "OpenTelemetryXRay", dependencies: [


### PR DESCRIPTION
Update slashmo/swift-otel dependency for apple/swift-distributed-tracing 1.0 support.