### PR TITLE
Updating to follow the tatest swift-otel

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,11 +8,13 @@ let package = Package(
         .library(name: "OpenTelemetryXRay", targets: ["OpenTelemetryXRay"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/slashmo/swift-otel.git", .upToNextMinor(from: "0.8.0")),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
+        .package(url: "https://github.com/slashmo/swift-otel.git", branch: "main"),
     ],
     targets: [
         .target(name: "OpenTelemetryXRay", dependencies: [
-            .product(name: "OpenTelemetry", package: "swift-otel"),
+            .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
+            .product(name: "OTel", package: "swift-otel"),
         ]),
         .testTarget(name: "OpenTelemetryXRayTests", dependencies: [
             .target(name: "OpenTelemetryXRay"),

--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,7 @@ let package = Package(
         ]),
         .testTarget(name: "OpenTelemetryXRayTests", dependencies: [
             .target(name: "OpenTelemetryXRay"),
+            .product(name: "OTel", package: "swift-otel"),
         ]),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -8,8 +8,8 @@ let package = Package(
         .library(name: "OpenTelemetryXRay", targets: ["OpenTelemetryXRay"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
         .package(url: "https://github.com/slashmo/swift-otel.git", branch: "main"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
     ],
     targets: [
         .target(name: "OpenTelemetryXRay", dependencies: [

--- a/Sources/OpenTelemetryXRay/Hex.swift
+++ b/Sources/OpenTelemetryXRay/Hex.swift
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2023 Moritz Lang and the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// A collection of utilities when working with hex strings.
+enum Hex {
+    /// A lockup table for quick conversion of bytes to hex-bytes.
+    static let lookup = [
+        UInt8(ascii: "0"), UInt8(ascii: "1"), UInt8(ascii: "2"), UInt8(ascii: "3"),
+        UInt8(ascii: "4"), UInt8(ascii: "5"), UInt8(ascii: "6"), UInt8(ascii: "7"),
+        UInt8(ascii: "8"), UInt8(ascii: "9"), UInt8(ascii: "a"), UInt8(ascii: "b"),
+        UInt8(ascii: "c"), UInt8(ascii: "d"), UInt8(ascii: "e"), UInt8(ascii: "f"),
+    ]
+
+    /// Convert the given ASCII bytes into bytes stored in the given target.
+    ///
+    /// - Warning: The target must be exactly half the size of the ASCII bytes.
+    ///
+    /// - Parameters:
+    ///   - ascii: The ASCII bytes to convert.
+    ///   - target: The pointer to store the converted bytes into.
+    static func convert<T>(
+        _ ascii: T,
+        toBytes target: UnsafeMutableRawBufferPointer
+    ) where T: RandomAccessCollection, T.Element == UInt8 {
+        assert(ascii.count / 2 == target.count, "Target needs half as much space as ascii")
+
+        var source = ascii.makeIterator()
+        var targetIndex = 0
+
+        while let major = source.next(), let minor = source.next() {
+            var byte: UInt8 = 0
+
+            switch major {
+            case UInt8(ascii: "0") ... UInt8(ascii: "9"):
+                byte = (major - UInt8(ascii: "0")) << 4
+            case UInt8(ascii: "a") ... UInt8(ascii: "f"):
+                byte = (major - UInt8(ascii: "a") + 10) << 4
+            default:
+                preconditionFailure()
+            }
+
+            switch minor {
+            case UInt8(ascii: "0") ... UInt8(ascii: "9"):
+                byte |= (minor - UInt8(ascii: "0"))
+            case UInt8(ascii: "a") ... UInt8(ascii: "f"):
+                byte |= (minor - UInt8(ascii: "a") + 10)
+            default:
+                preconditionFailure()
+            }
+
+            target[targetIndex] = byte
+            targetIndex += 1
+        }
+    }
+}

--- a/Sources/OpenTelemetryXRay/IDGenerator.swift
+++ b/Sources/OpenTelemetryXRay/IDGenerator.swift
@@ -1,8 +1,8 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the Swift OpenTelemetry open source project
+// This source file is part of the Swift OTel open source project
 //
-// Copyright (c) 2021 Moritz Lang and the Swift OpenTelemetry project authors
+// Copyright (c) 2021 Moritz Lang and the Swift OTel project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/OpenTelemetryXRay/IDGenerator.swift
+++ b/Sources/OpenTelemetryXRay/IDGenerator.swift
@@ -24,7 +24,7 @@ public struct XRayIDGenerator<NumberGenerator: RandomNumberGenerator & Sendable>
 
     /// Initialize an X-Ray compatible `OTelIDGenerator` backed by the given `RandomNumberGenerator`.
     ///
-    /// - Parameter randomNumberGenerator: The `RandomNumberGenerator` to use, defaults to a `SystemRandomNumberGenerator`.
+    /// - Parameter randomNumberGenerator: The `RandomNumberGenerator` to use.
     public init(randomNumberGenerator: NumberGenerator) {
         self.init(
             randomNumberGenerator: randomNumberGenerator,
@@ -74,6 +74,7 @@ extension DispatchWallTime {
 }
 
 extension XRayIDGenerator where NumberGenerator == SystemRandomNumberGenerator {
+    /// Initialize an X-Ray compatible `OTelIDGenerator` backed by the `SystemRandomNumberGenerator`.
     public init() {
         self.init(randomNumberGenerator: SystemRandomNumberGenerator())
     }

--- a/Sources/OpenTelemetryXRay/MetadataProvider+OTelXRay.swift
+++ b/Sources/OpenTelemetryXRay/MetadataProvider+OTelXRay.swift
@@ -1,8 +1,8 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the Swift OpenTelemetry open source project
+// This source file is part of the Swift OTel open source project
 //
-// Copyright (c) 2021 Moritz Lang and the Swift OpenTelemetry project authors
+// Copyright (c) 2021 Moritz Lang and the Swift OTel project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/OpenTelemetryXRay/Propagator.swift
+++ b/Sources/OpenTelemetryXRay/Propagator.swift
@@ -12,7 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 import Instrumentation
-@_exported import OpenTelemetry
+@_exported import OTel
 
 /// An `OTelPropagator` that propagates span context through the `X-Amzn-Trace-Id` header.
 ///
@@ -24,7 +24,7 @@ public struct XRayPropagator: OTelPropagator {
     public init() {}
 
     public func inject<Carrier, Inject>(
-        _ spanContext: OTel.SpanContext,
+        _ spanContext: OTelSpanContext,
         into carrier: inout Carrier,
         using injector: Inject
     ) where Inject: Injector, Carrier == Inject.Carrier {
@@ -44,14 +44,14 @@ public struct XRayPropagator: OTelPropagator {
     public func extractSpanContext<Carrier, Extract>(
         from carrier: Carrier,
         using extractor: Extract
-    ) throws -> OTel.SpanContext? where Extract: Extractor, Carrier == Extract.Carrier {
+    ) throws -> OTelSpanContext? where Extract: Extractor, Carrier == Extract.Carrier {
         guard let tracingHeader = extractor.extract(key: Self.tracingHeader, from: carrier) else {
             return nil
         }
 
-        var extractedTraceID: OTel.TraceID?
-        var spanID: OTel.SpanID?
-        var extractedTraceFlags: OTel.TraceFlags?
+        var extractedTraceID: OTelTraceID?
+        var spanID: OTelSpanID?
+        var extractedTraceFlags: OTelTraceFlags?
 
         let parts = tracingHeader.split(separator: ";")
         var iterator = parts.makeIterator()
@@ -74,15 +74,17 @@ public struct XRayPropagator: OTelPropagator {
             throw TraceHeaderParsingError(value: tracingHeader, reason: .missingTraceID)
         }
 
-        return OTel.SpanContext(
+        return OTelSpanContext(
             traceID: traceID,
-            spanID: spanID ?? OTel.SpanID(bytes: (0, 0, 0, 0, 0, 0, 0, 0)),
+            spanID: spanID ?? OTelSpanID(bytes: (0, 0, 0, 0, 0, 0, 0, 0)),
+            parentSpanID: nil,
             traceFlags: extractedTraceFlags ?? [],
+            traceState: nil,
             isRemote: true
         )
     }
 
-    private func extractTraceID(_ string: some StringProtocol) throws -> OTel.TraceID {
+    private func extractTraceID(_ string: some StringProtocol) throws -> OTelTraceID {
         let result = try string.utf8.withContiguousStorageIfAvailable { traceIDBytes -> OTel.TraceID in
             guard traceIDBytes.count == 35 else {
                 throw TraceHeaderParsingError(value: String(string), reason: .invalidTraceIDLength(string.count))
@@ -99,32 +101,32 @@ public struct XRayPropagator: OTelPropagator {
                 throw TraceHeaderParsingError(value: String(string), reason: .invalidTraceIDDelimiters)
             }
 
-            var traceIDStorage: OTel.TraceID.Bytes = (
+            var traceIDStorage: OTelTraceID.Bytes = (
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
             )
             withUnsafeMutableBytes(of: &traceIDStorage) { ptr in
                 let timestampRegion = UnsafeMutableRawBufferPointer(rebasing: ptr[0 ..< 4])
                 let randomRegion = UnsafeMutableRawBufferPointer(rebasing: ptr[4...])
-                OTel.Hex.convert(traceIDBytes[2 ..< 10], toBytes: timestampRegion)
-                OTel.Hex.convert(traceIDBytes[11 ..< 35], toBytes: randomRegion)
+                Hex.convert(traceIDBytes[2 ..< 10], toBytes: timestampRegion)
+                Hex.convert(traceIDBytes[11 ..< 35], toBytes: randomRegion)
             }
 
-            return OTel.TraceID(bytes: traceIDStorage)
+            return OTelTraceID(bytes: traceIDStorage)
         }
         return try result ?? extractTraceID(String(string))
     }
 
-    private func extractSpanID(_ string: some StringProtocol) throws -> OTel.SpanID {
+    private func extractSpanID(_ string: some StringProtocol) throws -> OTelSpanID {
         let result = try string.utf8.withContiguousStorageIfAvailable { spanIDBytes -> OTel.SpanID in
             guard spanIDBytes.count == 16 else {
                 throw TraceHeaderParsingError(value: String(string), reason: .invalidSpanIDLength(spanIDBytes.count))
             }
 
-            var bytes: OTel.SpanID.Bytes = (0, 0, 0, 0, 0, 0, 0, 0)
+            var bytes: OTelSpanID.Bytes = (0, 0, 0, 0, 0, 0, 0, 0)
             withUnsafeMutableBytes(of: &bytes) { ptr in
-                OTel.Hex.convert(spanIDBytes, toBytes: ptr)
+                Hex.convert(spanIDBytes, toBytes: ptr)
             }
-            return OTel.SpanID(bytes: bytes)
+            return OTelSpanID(bytes: bytes)
         }
         return try result ?? extractSpanID(String(string))
     }

--- a/Sources/OpenTelemetryXRay/Propagator.swift
+++ b/Sources/OpenTelemetryXRay/Propagator.swift
@@ -1,8 +1,8 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the Swift OpenTelemetry open source project
+// This source file is part of the Swift OTel open source project
 //
-// Copyright (c) 2021 Moritz Lang and the Swift OpenTelemetry project authors
+// Copyright (c) 2021 Moritz Lang and the Swift OTel project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -85,7 +85,7 @@ public struct XRayPropagator: OTelPropagator {
     }
 
     private func extractTraceID(_ string: some StringProtocol) throws -> OTelTraceID {
-        let result = try string.utf8.withContiguousStorageIfAvailable { traceIDBytes -> OTel.TraceID in
+        let result = try string.utf8.withContiguousStorageIfAvailable { traceIDBytes -> OTelTraceID in
             guard traceIDBytes.count == 35 else {
                 throw TraceHeaderParsingError(value: String(string), reason: .invalidTraceIDLength(string.count))
             }
@@ -117,7 +117,7 @@ public struct XRayPropagator: OTelPropagator {
     }
 
     private func extractSpanID(_ string: some StringProtocol) throws -> OTelSpanID {
-        let result = try string.utf8.withContiguousStorageIfAvailable { spanIDBytes -> OTel.SpanID in
+        let result = try string.utf8.withContiguousStorageIfAvailable { spanIDBytes -> OTelSpanID in
             guard spanIDBytes.count == 16 else {
                 throw TraceHeaderParsingError(value: String(string), reason: .invalidSpanIDLength(spanIDBytes.count))
             }

--- a/Tests/OpenTelemetryXRayTests/Helpers/XCTAssertThrowsEquatableError.swift
+++ b/Tests/OpenTelemetryXRayTests/Helpers/XCTAssertThrowsEquatableError.swift
@@ -1,8 +1,8 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the Swift OpenTelemetry open source project
+// This source file is part of the Swift OTel open source project
 //
-// Copyright (c) 2021 Moritz Lang and the Swift OpenTelemetry project authors
+// Copyright (c) 2021 Moritz Lang and the Swift OTel project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/OpenTelemetryXRayTests/IDGeneratorTests.swift
+++ b/Tests/OpenTelemetryXRayTests/IDGeneratorTests.swift
@@ -1,8 +1,8 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the Swift OpenTelemetry open source project
+// This source file is part of the Swift OTel open source project
 //
-// Copyright (c) 2021 Moritz Lang and the Swift OpenTelemetry project authors
+// Copyright (c) 2021 Moritz Lang and the Swift OTel project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/OpenTelemetryXRayTests/IDGeneratorTests.swift
+++ b/Tests/OpenTelemetryXRayTests/IDGeneratorTests.swift
@@ -16,26 +16,26 @@ import XCTest
 
 final class XRayIDGeneratorTests: XCTestCase {
     func test_generatesRandomTraceID() {
-        var idGenerator = XRayIDGenerator(
+        let idGenerator = XRayIDGenerator(
             randomNumberGenerator: ConstantNumberGenerator(value: .max),
             getCurrentSecondsSinceEpoch: { 1_616_064_590 }
         )
 
-        let maxTraceID = idGenerator.generateTraceID()
+        let maxTraceID = idGenerator.nextTraceID()
 
         XCTAssertEqual(
             maxTraceID,
-            OTel.TraceID(bytes: (96, 83, 48, 78, 255, 255, 255, 254, 255, 255, 255, 255, 255, 255, 255, 254))
+            OTelTraceID(bytes: (96, 83, 48, 78, 255, 255, 255, 254, 255, 255, 255, 255, 255, 255, 255, 254))
         )
     }
 
     func test_generatesRandomTraceID_withRandomNumberGenerator() {
-        var idGenerator = XRayIDGenerator(
+        let idGenerator = XRayIDGenerator(
             randomNumberGenerator: ConstantNumberGenerator(value: .random(in: 0 ..< .max)),
             getCurrentSecondsSinceEpoch: { 1_616_064_590 }
         )
 
-        let randomTraceID = idGenerator.generateTraceID()
+        let randomTraceID = idGenerator.nextTraceID()
 
         XCTAssertTrue(
             randomTraceID.description.starts(with: "6053304e"),
@@ -44,24 +44,24 @@ final class XRayIDGeneratorTests: XCTestCase {
     }
 
     func test_generatesUniqueTraceIDs() {
-        var idGenerator = XRayIDGenerator()
-        var traceIDs = Set<OTel.TraceID>()
+        let idGenerator = XRayIDGenerator()
+        var traceIDs = Set<OTelTraceID>()
 
         for _ in 0 ..< 1000 {
-            traceIDs.insert(idGenerator.generateTraceID())
+            traceIDs.insert(idGenerator.nextTraceID())
         }
 
         XCTAssertEqual(traceIDs.count, 1000, "Generating 1000 X-Ray trace ids should result in 1000 unique trace ids.")
     }
 
     func test_generatesRandomSpanID() {
-        var idGenerator = XRayIDGenerator(randomNumberGenerator: ConstantNumberGenerator(value: .max))
+        let idGenerator = XRayIDGenerator(randomNumberGenerator: ConstantNumberGenerator(value: .max))
 
-        let maxSpanID = idGenerator.generateSpanID()
+        let maxSpanID = idGenerator.nextSpanID()
 
         XCTAssertEqual(
             maxSpanID,
-            OTel.SpanID(bytes: (255, 255, 255, 255, 255, 255, 255, 255))
+            OTelSpanID(bytes: (255, 255, 255, 255, 255, 255, 255, 255))
         )
     }
 
@@ -69,19 +69,19 @@ final class XRayIDGeneratorTests: XCTestCase {
         let randomValue = UInt64.random(in: 0 ..< .max)
         let randomHexString = String(randomValue, radix: 16, uppercase: false)
         let hexString = randomHexString.count == 16 ? randomHexString : "0\(randomHexString)"
-        var idGenerator = XRayIDGenerator(randomNumberGenerator: ConstantNumberGenerator(value: randomValue))
+        let idGenerator = XRayIDGenerator(randomNumberGenerator: ConstantNumberGenerator(value: randomValue))
 
-        let randomSpanID = idGenerator.generateSpanID()
+        let randomSpanID = idGenerator.nextSpanID()
 
         XCTAssertEqual(randomSpanID.description, hexString)
     }
 
     func test_generatesUniqueSpanIDs() {
-        var idGenerator = XRayIDGenerator()
-        var spanIDs = Set<OTel.SpanID>()
+        let idGenerator = XRayIDGenerator()
+        var spanIDs = Set<OTelSpanID>()
 
         for _ in 0 ..< 1000 {
-            spanIDs.insert(idGenerator.generateSpanID())
+            spanIDs.insert(idGenerator.nextSpanID())
         }
 
         XCTAssertEqual(spanIDs.count, 1000, "Generating 1000 span ids should result in 1000 unique span ids.")

--- a/Tests/OpenTelemetryXRayTests/MetadataProviderTests.swift
+++ b/Tests/OpenTelemetryXRayTests/MetadataProviderTests.swift
@@ -27,12 +27,14 @@ final class MetadataProviderTests: XCTestCase {
         var logger = Logger(label: "test")
         logger.handler = StreamLogHandler(label: "test", stream: stream, metadataProvider: .otelXRay)
 
-        var generator = XRayIDGenerator()
+        let generator = XRayIDGenerator()
 
-        let spanContext = OTel.SpanContext(
-            traceID: generator.generateTraceID(),
-            spanID: generator.generateSpanID(),
+        let spanContext = OTelSpanContext(
+            traceID: generator.nextTraceID(),
+            spanID: generator.nextSpanID(),
+            parentSpanID: nil,
             traceFlags: .sampled,
+            traceState: nil,
             isRemote: true
         )
 
@@ -66,12 +68,14 @@ final class MetadataProviderTests: XCTestCase {
         let metadataProvider = Logger.MetadataProvider.otelXRay(traceIDKey: "custom_trace_id", spanIDKey: "custom_span_id")
         logger.handler = StreamLogHandler(label: "test", stream: stream, metadataProvider: metadataProvider)
 
-        var generator = XRayIDGenerator()
+        let generator = XRayIDGenerator()
 
-        let spanContext = OTel.SpanContext(
-            traceID: generator.generateTraceID(),
-            spanID: generator.generateSpanID(),
+        let spanContext = OTelSpanContext(
+            traceID: generator.nextTraceID(),
+            spanID: generator.nextSpanID(),
+            parentSpanID: nil,
             traceFlags: .sampled,
+            traceState: nil,
             isRemote: true
         )
 

--- a/Tests/OpenTelemetryXRayTests/MetadataProviderTests.swift
+++ b/Tests/OpenTelemetryXRayTests/MetadataProviderTests.swift
@@ -1,8 +1,8 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the Swift OpenTelemetry open source project
+// This source file is part of the Swift OTel open source project
 //
-// Copyright (c) 2021 Moritz Lang and the Swift OpenTelemetry project authors
+// Copyright (c) 2021 Moritz Lang and the Swift OTel project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -12,8 +12,8 @@
 //===----------------------------------------------------------------------===//
 
 @testable import Logging
-@testable import OpenTelemetry
 @testable import OpenTelemetryXRay
+@testable import OTel
 import ServiceContextModule
 import XCTest
 

--- a/Tests/OpenTelemetryXRayTests/PropagatorTests.swift
+++ b/Tests/OpenTelemetryXRayTests/PropagatorTests.swift
@@ -1,8 +1,8 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the Swift OpenTelemetry open source project
+// This source file is part of the Swift OTel open source project
 //
-// Copyright (c) 2021 Moritz Lang and the Swift OpenTelemetry project authors
+// Copyright (c) 2021 Moritz Lang and the Swift OTel project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/OpenTelemetryXRayTests/PropagatorTests.swift
+++ b/Tests/OpenTelemetryXRayTests/PropagatorTests.swift
@@ -23,10 +23,12 @@ final class XRayPropagatorTests: XCTestCase {
     // MARK: - Inject
 
     func test_injectsTraceparentHeader_notSampled() {
-        let spanContext = OTel.SpanContext(
-            traceID: OTel.TraceID(bytes: (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)),
-            spanID: OTel.SpanID(bytes: (1, 2, 3, 4, 5, 6, 7, 8)),
+        let spanContext = OTelSpanContext(
+            traceID: OTelTraceID(bytes: (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)),
+            spanID: OTelSpanID(bytes: (1, 2, 3, 4, 5, 6, 7, 8)),
+            parentSpanID: nil,
             traceFlags: [],
+            traceState: nil,
             isRemote: false
         )
         var headers = [String: String]()
@@ -40,10 +42,12 @@ final class XRayPropagatorTests: XCTestCase {
     }
 
     func test_injectsTraceparentHeader_sampled() {
-        let spanContext = OTel.SpanContext(
-            traceID: OTel.TraceID(bytes: (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)),
-            spanID: OTel.SpanID(bytes: (1, 2, 3, 4, 5, 6, 7, 8)),
+        let spanContext = OTelSpanContext(
+            traceID: OTelTraceID(bytes: (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)),
+            spanID: OTelSpanID(bytes: (1, 2, 3, 4, 5, 6, 7, 8)),
+            parentSpanID: nil,
             traceFlags: .sampled,
+            traceState: nil,
             isRemote: false
         )
         var headers = [String: String]()

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 ##===----------------------------------------------------------------------===##
 ##
-## This source file is part of the Swift OpenTelemetry open source project
+## This source file is part of the Swift OTel open source project
 ##
-## Copyright (c) 2021 Moritz Lang and the Swift OpenTelemetry project authors
+## Copyright (c) 2021 Moritz Lang and the Swift OTel project authors
 ## Licensed under Apache License v2.0
 ##
 ## See LICENSE.txt for license information

--- a/scripts/validate_format.sh
+++ b/scripts/validate_format.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 ##===----------------------------------------------------------------------===##
 ##
-## This source file is part of the Swift OpenTelemetry open source project
+## This source file is part of the Swift OTel open source project
 ##
-## Copyright (c) 2021 Moritz Lang and the Swift OpenTelemetry project authors
+## Copyright (c) 2021 Moritz Lang and the Swift OTel project authors
 ## Licensed under Apache License v2.0
 ##
 ## See LICENSE.txt for license information

--- a/scripts/validate_license_headers.sh
+++ b/scripts/validate_license_headers.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 ##===----------------------------------------------------------------------===##
 ##
-## This source file is part of the Swift OpenTelemetry open source project
+## This source file is part of the Swift OTel open source project
 ##
-## Copyright (c) 2021 Moritz Lang and the Swift OpenTelemetry project authors
+## Copyright (c) 2021 Moritz Lang and the Swift OTel project authors
 ## Licensed under Apache License v2.0
 ##
 ## See LICENSE.txt for license information
@@ -31,7 +31,7 @@ here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function replace_acceptable_years() {
   # this needs to replace all acceptable forms with 'YEARS'
-  sed -e 's/2020-2021/YEARS/' -e 's/2021/YEARS/'
+  sed -e 's/202[1234]/YEARS/'
 }
 
 printf "=> Checking license headers\n"
@@ -50,9 +50,9 @@ for language in swift-or-c bash dtrace; do
         cat > "$tmp" <<"EOF"
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the Swift OpenTelemetry open source project
+// This source file is part of the Swift OTel open source project
 //
-// Copyright (c) YEARS Moritz Lang and the Swift OpenTelemetry project authors
+// Copyright (c) YEARS Moritz Lang and the Swift OTel project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -68,9 +68,9 @@ EOF
 #!/bin/bash
 ##===----------------------------------------------------------------------===##
 ##
-## This source file is part of the Swift OpenTelemetry open source project
+## This source file is part of the Swift OTel open source project
 ##
-## Copyright (c) YEARS Moritz Lang and the Swift OpenTelemetry project authors
+## Copyright (c) YEARS Moritz Lang and the Swift OTel project authors
 ## Licensed under Apache License v2.0
 ##
 ## See LICENSE.txt for license information
@@ -86,9 +86,9 @@ EOF
 #!/usr/sbin/dtrace -q -s
 /*===----------------------------------------------------------------------===*
  *
- *  This source file is part of the Swift OpenTelemetry open source project
+ *  This source file is part of the Swift OTel open source project
  *
- *  Copyright (c) YEARS Moritz Lang and the Swift OpenTelemetry project authors
+ *  Copyright (c) YEARS Moritz Lang and the Swift OTel project authors
  *  Licensed under Apache License v2.0
  *
  *  See LICENSE.txt for license information


### PR DESCRIPTION
As the title suggests, the following adjustments have been made:

- Updated to follow the type name changes in the `OTel` module.
- Modified the injection method for `RandomNumberGenerator` to match the style used in `swift-otel`.
- Updated to reflect the method name changes in the `OTelIDGenerator`P protocol.
- Copied and pasted `swift-otel`'s `Hex` for reuse. It appears that this was made `public` at one point, but it seems to have reverted back to `internal`.